### PR TITLE
add vendor type classes

### DIFF
--- a/lib/qbwc_requests/vendor_type/v07/query.rb
+++ b/lib/qbwc_requests/vendor_type/v07/query.rb
@@ -1,0 +1,9 @@
+module QbwcRequests
+  module VendorType
+    module V07
+      class Query < QbwcRequests::Base
+        field :max_returned
+      end
+    end
+  end
+end

--- a/spec/vendor_type_qbxml_spec.rb
+++ b/spec/vendor_type_qbxml_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe VendorTypeQbxml do
+
+  describe VendorTypeQbxml::Query do
+
+    context "V07" do
+      it_behaves_like 'queryable'
+    end
+
+  end
+
+end


### PR DESCRIPTION
We want to start pulling vendor types from QuickBooks into Procore.  In order to do that, we need to add vendor type classes to create the correct request to send to QuickBooks.