### PR TITLE
add fields to the po query object

### DIFF
--- a/lib/qbwc_requests/purchase_order/v07/query.rb
+++ b/lib/qbwc_requests/purchase_order/v07/query.rb
@@ -3,6 +3,8 @@ module QbwcRequests
     module V07
       class Query < QbwcRequests::Base
         field :max_returned
+        field :txn_id
+        field :include_line_items
       end
     end
   end


### PR DESCRIPTION
We needed to add a couple of extra fields to the purchase order query class