### PR TITLE
remove qbxml from dependency add to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in qbwc_requests.gemspec
 gem 'rspec'
 gem 'pry'
+gem 'qbxml', :github => 'qbwc/qbxml'
+
 gemspec

--- a/lib/qbwc_requests.rb
+++ b/lib/qbwc_requests.rb
@@ -4,7 +4,6 @@ require "qbwc_requests/ordered_fields"
 require "qbwc_requests/xml_actions"
 require "qbwc_requests/base"
 require "qbwc_requests/factory"
-require "qbxml"
 
 qbxml_models = [
   "account",

--- a/qbwc_requests.gemspec
+++ b/qbwc_requests.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "qbxml", "~> 0.3.0"
   spec.add_runtime_dependency "activemodel", "~> 4"
   spec.add_development_dependency "colorize", "~> 0.7.7"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Basically, our gem was using another gem , Qbxml, as a way to translate data sent to and returned from QB.  We do not own this gem and changes were made to it that fixed a couple issues that are currently breaking functionality for some of our QB customers. 

After creating an issue asking for the version to be bumped so that we could get the newest committed code and not hearing back for ~ 1 week, we are now removing the Qbxml from our Gem's spec file and including it as a regular gem that points to the most recent code in Github.