### PR TITLE
Tc/add txn filtering for general detail report

### DIFF
--- a/lib/qbwc_requests/general_detail_report/v07/query.rb
+++ b/lib/qbwc_requests/general_detail_report/v07/query.rb
@@ -5,6 +5,7 @@ module QbwcRequests
         field :max_returned
         field :general_detail_report_type
         field :report_entity_filter
+        field :report_txn_type_filter
         field :include_column
       end
     end


### PR DESCRIPTION
We need to be able to filter the general report by transaction types in order to limit the response for commitment invoices to only those attached to PO's in QuickBooks.
@joniles 