### PR TITLE
Add report date macro filter

### DIFF
--- a/lib/qbwc_requests/general_detail_report/v07/query.rb
+++ b/lib/qbwc_requests/general_detail_report/v07/query.rb
@@ -8,6 +8,7 @@ module QbwcRequests
         field :report_entity_filter
         field :report_account_filter
         field :report_txn_type_filter
+        field :report_modified_date_range_macro
         field :include_column
       end
     end

--- a/lib/qbwc_requests/general_detail_report/v07/query.rb
+++ b/lib/qbwc_requests/general_detail_report/v07/query.rb
@@ -4,10 +4,10 @@ module QbwcRequests
       class Query < QbwcRequests::Base
         field :max_returned
         field :general_detail_report_type
+        field :report_date_macro
         field :report_entity_filter
         field :report_account_filter
         field :report_txn_type_filter
-        field :report_modified_date_range_macro
         field :include_column
       end
     end


### PR DESCRIPTION
The current report date filter is not working exactly as intended.  This report period filter allows us to be more specific and return all the desired data.  @joniles 