### PR TITLE
Fix bill max ref no length

### DIFF
--- a/lib/qbwc_requests/bill/v07/add.rb
+++ b/lib/qbwc_requests/bill/v07/add.rb
@@ -8,6 +8,7 @@ module QbwcRequests
         field :due_date
         field :ref_number
         field :memo
+        field :link_to_txn_id
         field :expense_line_add
         field :item_line_add
 

--- a/lib/qbwc_requests/bill/v07/add.rb
+++ b/lib/qbwc_requests/bill/v07/add.rb
@@ -8,7 +8,6 @@ module QbwcRequests
         field :due_date
         field :ref_number
         field :memo
-        field :link_to_txn_id
         field :expense_line_add
         field :item_line_add
 

--- a/lib/qbwc_requests/bill/v07/add.rb
+++ b/lib/qbwc_requests/bill/v07/add.rb
@@ -13,7 +13,7 @@ module QbwcRequests
         field :item_line_add
 
         validates :memo, length: { maximum: 4095 }
-        validates :ref_number, length: { maximum: 11 }
+        validates :ref_number, length: { maximum: 20 }
       end
     end
   end


### PR DESCRIPTION
Quickbooks actually allows 20 characters in the reference number field