### PR TITLE
Relax activemodel dependency, to allow coexistence in Rails 5 project

### DIFF
--- a/qbwc_requests.gemspec
+++ b/qbwc_requests.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "qbxml", "~> 0.3.0"
-  spec.add_runtime_dependency "activemodel", "~> 4"
+  spec.add_runtime_dependency "activemodel", ">= 4", "< 6"
   spec.add_development_dependency "colorize", "~> 0.7.7"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
All specs pass with the latest release `activemodel` gem. Is that sufficient? 