### PR TITLE
Add txn id to bill query

### DIFF
--- a/lib/qbwc_requests/bill/v07/query.rb
+++ b/lib/qbwc_requests/bill/v07/query.rb
@@ -2,6 +2,7 @@ module QbwcRequests
   module Bill
     module V07
       class Query < QbwcRequests::Base
+        field :txn_id
         field :max_returned
         field :entity_filter
         field :include_line_items


### PR DESCRIPTION
### Context
Need to check if a Requisition still exists in Quickbooks before unlinking.

### Changes
Add txn_id to Bill Query class