### PR TITLE
Update gem dep for qbxml

### DIFF
--- a/lib/qbwc_requests/version.rb
+++ b/lib/qbwc_requests/version.rb
@@ -1,3 +1,3 @@
 module QbwcRequests
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/qbwc_requests.gemspec
+++ b/qbwc_requests.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "qbxml", "~> 0.3.0"
+  spec.add_runtime_dependency "qbxml", "~> 0.4.0"
   spec.add_runtime_dependency "activemodel", ">= 4"
   spec.add_development_dependency "colorize", "~> 0.7.7"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
### Description
We are working to update our Quickbooks integration, which relies on
`qbxml` and `qbwc_requests` 

We rely on `qbxml` specifically on this [commit](https://github.com/qbwc/qbxml/commit/f91b0bad35f22f0c5cc1518db7f09ac4e8c91935#diff-5903e5b5887d3c0c64889648f776b614ad8fef7d8188868f872857d7f3dd24c6)

These changes have been merged to master allowing us to use `qbxml, 0.4.0` and update to `Ruby 2.7.3`
However, `qbwc_requests` has `qbxml, 0.3.0` dependency specified.

This PR is to update that dependency to `0.4.0`

### Testing notes.

I pulled `qbxml, 0.4.0` at master down and specified its' local path to our Quickbooks integration Gemfile
I pulled down `qbwc_requets` master down, also specifying a local path to our Quickbooks integration Gemfile

- [X] Bundle install , specs and rails server are successful using `ruby 2.7.3`

